### PR TITLE
cleanup: refresh Brewfile, fix macOS defaults bugs, drop dead code

### DIFF
--- a/.Brewfile.core
+++ b/.Brewfile.core
@@ -69,6 +69,8 @@ brew "yq"
 brew "tree"
 # Render Markdown files in terminal
 brew "glow"
+# Modern command runner (Makefile alternative)
+brew "just"
 
 # ========================================
 # Version Control
@@ -80,8 +82,10 @@ brew "git"
 brew "gh"
 # Enhanced diff viewer for Git output
 brew "git-delta"
-# Colorized diff utility
-brew "colordiff"
+# Structural diff that understands syntax
+brew "difftastic"
+# Terminal UI for git operations
+brew "lazygit"
 
 # ========================================
 # Editor
@@ -166,3 +170,5 @@ brew "hcloud"
 
 # Language server for Terraform configuration
 brew "hashicorp/tap/terraform-ls"
+# OpenTofu - open-source Terraform fork
+brew "opentofu"

--- a/.Brewfile.extras
+++ b/.Brewfile.extras
@@ -34,10 +34,6 @@ tap "manaflow-ai/cmux"
 tap "fluxcd/tap"
 # Talos Linux CLI for homelab clusters
 tap "siderolabs/tap"
-# Azure AD authentication plugin for kubectl
-tap "Azure/kubelogin"
-# Generic OIDC kubectl plugin
-tap "int128/kubelogin"
 
 # ========================================
 # Kubernetes Extras
@@ -59,11 +55,6 @@ brew "argocd"
 brew "siderolabs/tap/talosctl"
 # Inspect and manage container images and registries
 brew "crane"
-# Azure AD client-go credential plugin (kubectl + AKS)
-brew "Azure/kubelogin/kubelogin"
-# OIDC kubectl plugin (kubectl oidc-login). Note: binary name `kubelogin` collides
-# with Azure/kubelogin/kubelogin above; pick one if `brew bundle` complains.
-brew "int128/kubelogin/kubelogin"
 
 # ========================================
 # Build & Compilation Tools

--- a/.Brewfile.extras
+++ b/.Brewfile.extras
@@ -29,7 +29,15 @@ tap "sandreas/tap"
 # A CLI for configuring "Night Shift" on macOS
 tap "smudge/smudge"
 # A lightweight, native macOS terminal built on Ghostty for managing multiple AI coding agents
-tap manaflow-ai/cmux
+tap "manaflow-ai/cmux"
+# Flux GitOps toolkit
+tap "fluxcd/tap"
+# Talos Linux CLI for homelab clusters
+tap "siderolabs/tap"
+# Azure AD authentication plugin for kubectl
+tap "Azure/kubelogin"
+# Generic OIDC kubectl plugin
+tap "int128/kubelogin"
 
 # ========================================
 # Kubernetes Extras
@@ -39,6 +47,23 @@ tap manaflow-ai/cmux
 brew "kind"
 # Validate Kubernetes manifests against schemas
 brew "kubeconform"
+# Explore Docker image layers and find wasted space
+brew "dive"
+# Manage SealedSecrets for GitOps workflows
+brew "kubeseal"
+# Flux CLI for GitOps continuous delivery
+brew "fluxcd/tap/flux"
+# Argo CD CLI for declarative GitOps
+brew "argocd"
+# Talos Linux CLI for managing homelab clusters
+brew "siderolabs/tap/talosctl"
+# Inspect and manage container images and registries
+brew "crane"
+# Azure AD client-go credential plugin (kubectl + AKS)
+brew "Azure/kubelogin/kubelogin"
+# OIDC kubectl plugin (kubectl oidc-login). Note: binary name `kubelogin` collides
+# with Azure/kubelogin/kubelogin above; pick one if `brew bundle` complains.
+brew "int128/kubelogin/kubelogin"
 
 # ========================================
 # Build & Compilation Tools
@@ -67,10 +92,12 @@ brew "ipcalc"
 brew "iproute2mac"
 # Mobile shell for resilient SSH connections
 brew "mosh"
-# Classic telnet client for legacy systems
-brew "telnet"
 # Non-interactive network downloader
 brew "wget"
+# Modern HTTP client (HTTPie clone, in Rust)
+brew "xh"
+# Statistical command-line benchmarking tool
+brew "hyperfine"
 
 # ========================================
 # Media & Imaging
@@ -93,22 +120,36 @@ brew "libheif"
 # CLI Utilities & Productivity
 # ========================================
 
+# Magical shell history with sync, search, and stats
+brew "atuin"
 # Interactive cheatsheet navigator for the terminal
 brew "navi"
-# System info dashboard for shell screenshots
-brew "neofetch"
-# Context-aware correction of previous console commands
-brew "thefuck"
+# Modern system info dashboard (replaces archived neofetch)
+brew "fastfetch"
 # Community-driven TL;DR cheatsheets viewer
 brew "tldr"
 # Count lines of code across languages
 brew "cloc"
+# Fast, accurate code statistics by language
+brew "tokei"
 # Capture terminal output as shareable images
 brew "homeport/tap/termshot"
 # Markdown linter with extensible rules
 brew "markdownlint-cli2"
-# GNU indent for C/C++ source formatting
-brew "gnu-indent"
+# Prose linter for documentation
+brew "vale"
+# Terminal file manager with image previews
+brew "yazi"
+# More intuitive du in Rust
+brew "dust"
+# Modern, colorful ps replacement
+brew "procs"
+# Intuitive find/sed alternative
+brew "sd"
+# Make JSON greppable
+brew "gron"
+# AI on the command line (Charm)
+brew "mods"
 # A CLI for configuring "Night Shift" on macOS
 brew "smudge/smudge/nightlight"
 
@@ -118,12 +159,6 @@ brew "smudge/smudge/nightlight"
 
 # Run GitHub Actions workflows locally
 brew "act"
-# ========================================
-# Cloud Storage
-# ========================================
-
-# Backblaze B2 storage management utilities
-brew "b2-tools"
 
 # ========================================
 # Mac App Store CLI
@@ -136,15 +171,13 @@ brew "mas"
 # Homebrew Casks (GUI Applications)
 # ========================================
 
-# Remove outdated Xcode caches to reclaim disk space
-cask "devcleaner"
 # Vector illustration editor for SVG workflows
 cask "inkscape"
 # Customize macOS menu bar icons
 cask "jordanbaird-ice"
 # Terminal emulator with platform-native UI and GPU acceleration
 cask "ghostty"
-# Terminal emulator with a lightweight, native macOS terminal built on Ghostty for managing multiple AI coding agents. 
+# Lightweight native macOS terminal built on Ghostty for managing multiple AI coding agents
 cask "cmux"
 # Note-taking with Markdown and bidirectional linking
 cask "obsidian"
@@ -152,8 +185,6 @@ cask "obsidian"
 cask "tailscale"
 # Spotlight replacement with extensions
 cask "raycast"
-# Kubernetes IDE
-cask "lens"
 # Encrypted messaging
 cask "signal"
 # Messaging app
@@ -174,8 +205,8 @@ cask "raspberry-pi-imager"
 cask "slack"
 # Voice, video, and text chat
 #cask "discord"
-# API development and testing
-cask "postman"
+# API client and design platform (Postman alternative)
+cask "bruno"
 # AI-powered code editor
 cask "cursor"
 

--- a/.Brewfile.extras
+++ b/.Brewfile.extras
@@ -165,7 +165,9 @@ cask "jordanbaird-ice"
 # Terminal emulator with platform-native UI and GPU acceleration
 cask "ghostty"
 # Lightweight native macOS terminal built on Ghostty for managing multiple AI coding agents
-cask "cmux"
+# Pinned manually to 0.62.2 Build 77 due to cmux PTY regression in 0.63.x
+# See https://github.com/manaflow-ai/cmux/issues/2636
+# cask "cmux"
 # Note-taking with Markdown and bidirectional linking
 cask "obsidian"
 # VPN mesh networking

--- a/.Brewfile.extras
+++ b/.Brewfile.extras
@@ -32,8 +32,6 @@ tap "smudge/smudge"
 tap "manaflow-ai/cmux"
 # Flux GitOps toolkit
 tap "fluxcd/tap"
-# Talos Linux CLI for homelab clusters
-tap "siderolabs/tap"
 
 # ========================================
 # Kubernetes Extras
@@ -51,8 +49,6 @@ brew "kubeseal"
 brew "fluxcd/tap/flux"
 # Argo CD CLI for declarative GitOps
 brew "argocd"
-# Talos Linux CLI for managing homelab clusters
-brew "siderolabs/tap/talosctl"
 # Inspect and manage container images and registries
 brew "crane"
 

--- a/.config/fish/conf.d/atuin.fish
+++ b/.config/fish/conf.d/atuin.fish
@@ -1,7 +1,10 @@
 if status is-interactive
-    if type -q atuin
+    # Manual installer drops env.fish; brew install puts atuin on PATH directly
+    if test -f "$HOME/.atuin/bin/env.fish"
         source "$HOME/.atuin/bin/env.fish"
+    end
 
+    if type -q atuin
         atuin init fish --disable-up-arrow | source
         atuin gen-completions --shell fish | source
     end

--- a/.config/fish/conf.d/env.fish
+++ b/.config/fish/conf.d/env.fish
@@ -9,6 +9,11 @@ set -q EDITOR; or set -x EDITOR nvim
 set -q VISUAL; or set -x VISUAL nvim
 set -q PAGER; or set -x PAGER less
 
+# Tell terminal-aware tools we're dark-on-light so they skip OSC 11 / ?997
+# capability queries. Respected by bat, delta, vim, and most ratatui TUIs.
+# Also a small per-prompt perf win on every terminal.
+set -q COLORFGBG; or set -x COLORFGBG "15;0"
+
 # Go settings (persistent defaults)
 set -q GO111MODULE; or set -x GO111MODULE on
 

--- a/.config/fish/conf.d/integration.fish
+++ b/.config/fish/conf.d/integration.fish
@@ -13,9 +13,3 @@ if type -q ts-k8s-auth
     ts-k8s-auth generate integration fish | source
     ts-k8s-auth completion fish | source
 end
-
-# --- the-fuck integration ---
-if type -q thefuck
-    thefuck --alias wtf | source
-    abbr -a wtf 'wtf --yeah'
-end

--- a/.config/oh-my-posh/themes/tron-cedi.omp.json
+++ b/.config/oh-my-posh/themes/tron-cedi.omp.json
@@ -30,12 +30,12 @@
   "secondary_prompt": {
     "template": " ❯❯ ",
     "foreground": "p:foreground",
-    "background": "transparent"
+    "background": "p:background"
   },
   "transient_prompt": {
     "template": "{{ .PWD }} ❯ ",
     "foreground": "p:foreground",
-    "background": "transparent"
+    "background": "p:background"
   },
   "console_title_template": "{{ .PWD }} :: {{ .UserName }}@{{ .HostName }}",
   "blocks": [

--- a/.gitconfig
+++ b/.gitconfig
@@ -77,6 +77,8 @@
 
 [delta]
     navigate = true    # use n and N to move between diff sections
+    dark = true        # skip OSC 11 background-color query (cmux PTY can't proxy responses)
+    syntax-theme = Dracula
 
 [merge]
     conflictstyle = diff3

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -57,7 +57,7 @@ CORE_APT_PACKAGES=(
 # Extra packages (networking, media, build tools)
 EXTRAS_APT_PACKAGES=(
   mosh socat rsync tcpdump
-  lldpad neofetch
+  lldpad fastfetch
   apt-transport-https
 )
 
@@ -518,7 +518,7 @@ run_custom_menu() {
 
   confirm "  Server APT packages (fish, tmux, neovim, etc.)?" && components+=("server_apt")
   confirm "  Core APT packages (build-essential, jq, python)?" && components+=("core_apt")
-  confirm "  Extra APT packages (mosh, tcpdump, neofetch)?" && components+=("extras_apt")
+  confirm "  Extra APT packages (mosh, tcpdump, fastfetch)?" && components+=("extras_apt")
   confirm "  eza (modern ls)?" && components+=("eza")
   confirm "  GitHub CLI?" && components+=("gh")
   confirm "  oh-my-posh (prompt theme)?" && components+=("oh_my_posh")

--- a/install_macos.sh
+++ b/install_macos.sh
@@ -263,6 +263,41 @@ install_stow() {
   fi
 }
 
+set_default_shell() {
+  print_header "Default Shell"
+
+  if ! is_installed fish; then
+    print_status "error" "fish not installed - run Brewfile first"
+    return 1
+  fi
+
+  local fish_path
+  fish_path="$(command -v fish)"
+
+  # macOS stores the user's login shell in Directory Services, not $SHELL
+  local current_shell
+  current_shell="$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')"
+
+  if [[ "$current_shell" == "$fish_path" ]]; then
+    print_status "skip" "fish is already the default shell"
+    return 0
+  fi
+
+  # /etc/shells must list fish before chsh will accept it
+  if ! grep -qxF "$fish_path" /etc/shells; then
+    print_status "install" "Adding $fish_path to /etc/shells (requires password)..."
+    echo "$fish_path" | sudo tee -a /etc/shells >/dev/null
+  fi
+
+  print_status "install" "Setting fish as default login shell..."
+  if chsh -s "$fish_path"; then
+    print_status "ok" "Default shell: $fish_path (takes effect on next login)"
+  else
+    print_status "error" "chsh to $fish_path failed"
+    return 1
+  fi
+}
+
 install_mise_runtimes() {
   print_header "Language Runtimes (mise)"
 
@@ -369,6 +404,7 @@ run_custom_menu() {
   confirm "  VS Code extensions?" && components+=("vscode")
   confirm "  System fonts (FiraCode, Nerd Fonts)?" && components+=("fonts")
   confirm "  Symlink dotfiles (stow)?" && components+=("stow")
+  confirm "  Set fish as default login shell?" && components+=("shell")
   confirm "  Language runtimes (mise: node, python, go, rust)?" && components+=("mise")
   confirm "  Krew (kubectl plugin manager)?" && components+=("krew")
   confirm "  Dock configuration (layout and spacers)?" && components+=("dock")
@@ -409,6 +445,7 @@ main() {
       install_brewfile "$DOTFILES_DIR/.Brewfile.vscode" "VS Code"
       install_fonts
       install_stow
+      set_default_shell
       install_mise_runtimes
       install_krew
       configure_macos_defaults
@@ -420,6 +457,7 @@ main() {
       install_brewfile "$DOTFILES_DIR/.Brewfile.core" "Core"
       install_fonts
       install_stow
+      set_default_shell
       configure_macos_defaults
       configure_dock
       ;;
@@ -437,6 +475,7 @@ main() {
           vscode)   install_brewfile "$DOTFILES_DIR/.Brewfile.vscode" "VS Code" ;;
           fonts)    install_fonts ;;
           stow)     install_stow ;;
+          shell)    set_default_shell ;;
           mise)     install_mise_runtimes ;;
           krew)     install_krew ;;
           dock)     configure_dock ;;

--- a/setup_dock.sh
+++ b/setup_dock.sh
@@ -118,12 +118,12 @@ configure_dock_apps() {
   # Browser: Chrome on work mac (zoe), Safari elsewhere
   if [[ "$(hostname -s)" == "zoe" ]]; then
     add_app "/Applications/Google Chrome.app" "Chrome" ||
-      add_app "/Applications/Arc.app" "Arc" ||
+      add_app "/Applications/Helium.app" "Helium" ||
       add_app "/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app" "Safari"
   else
-    add_app "/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app" "Safari" ||
+    add_app "/Applications/Helium.app" "Helium" ||
+      add_app "/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app" "Safari" ||
       add_app "/Applications/Safari.app" "Safari" ||
-      add_app "/Applications/Arc.app" "Arc" ||
       add_app "/Applications/Google Chrome.app" "Chrome"
   fi
 
@@ -152,11 +152,11 @@ configure_dock_apps() {
   # ────────────────────────────────────────────────────────────
   # Group 4: Development Tools
   # ────────────────────────────────────────────────────────────
-  add_app "/Applications/Ghostty.app" "Ghostty" ||
+  add_app "/Applications/cmux.app" "cmux" ||
+    add_app "/Applications/Ghostty.app" "Ghostty" ||
     add_app "/Applications/iTerm.app" "iTerm" ||
     add_app "/System/Applications/Utilities/Terminal.app" "Terminal"
 
-  add_app "/Applications/cmux.app" "cmux"
   add_app "/Applications/Cursor.app" "Cursor" ||
     add_app "/Applications/Visual Studio Code.app" "VSCode"
 

--- a/setup_macos_defaults.sh
+++ b/setup_macos_defaults.sh
@@ -62,11 +62,9 @@ configure_appearance() {
 configure_menubar() {
   print_header "Menu Bar"
 
-  # Auto-hide menu bar: In Full Screen Only
-  # 0 = Never, 1 = In Full Screen Only, 2 = Always
-  defaults write NSGlobalDomain AppleMenuBarVisibleInFullscreen -bool true
+  # Don't auto-hide the menu bar
   defaults write NSGlobalDomain _HIHideMenuBar -bool false
-  print_status "Menu bar: visible (auto-hide in full screen only)"
+  print_status "Menu bar: visible (no auto-hide)"
 
   # Recent documents, applications and servers
   defaults write NSGlobalDomain NSRecentDocumentsLimit -int 10
@@ -167,6 +165,10 @@ configure_finder() {
   defaults write com.apple.finder ShowPathbar -bool true
   print_status "Show path bar"
 
+  # Show full POSIX path in Finder window title (pairs with column view)
+  defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
+  print_status "Show full POSIX path in title"
+
   # Show status bar
   defaults write com.apple.finder ShowStatusBar -bool true
   print_status "Show status bar"
@@ -187,6 +189,14 @@ configure_finder() {
   defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
   defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
   print_status "Disabled .DS_Store on network/USB volumes"
+
+  # Save new documents to disk (not iCloud) by default
+  defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+  print_status "Default save location: local disk"
+
+  # Don't auto-launch Photos when a camera or SD card is connected
+  defaults write com.apple.ImageCapture disableHotPlug -bool true
+  print_status "Disabled Photos auto-launch on camera connect"
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -203,6 +213,10 @@ configure_keyboard() {
   # Short delay until repeat
   defaults write NSGlobalDomain InitialKeyRepeat -int 15
   print_status "Short delay until key repeat"
+
+  # Disable press-and-hold accent picker so vim/Neovim key repeat works
+  defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+  print_status "Press-and-hold disabled (key repeat for vim/Neovim)"
 
   # Disable auto-correct
   defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
@@ -304,7 +318,8 @@ configure_screenshots() {
   print_status "Screenshot format: PNG"
 
   # Disable shadow in screenshots
-  defaults write com.apple.screencapture disable-shadow -bool false
+  defaults write com.apple.screencapture disable-shadow -bool true
+  print_status "Screenshot shadow: disabled"
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -364,6 +379,7 @@ configure_remote_login() {
   # Check if already enabled
   if sudo systemsetup -getremotelogin 2>/dev/null | grep -q "On"; then
     print_status "Remote Login already enabled"
+    return 0
   fi
 
   echo -e "  ${BLUE}→${NC} Enabling Remote Login (requires password)..."
@@ -390,7 +406,7 @@ configure_security() {
     print_status "Gatekeeper already enabled"
   else
     echo -e "  ${BLUE}→${NC} Enabling Gatekeeper (requires password)..."
-    sudo spctl --master-enable
+    sudo spctl --global-enable
     print_status "Gatekeeper enabled"
   fi
   print_status "Allow apps from: App Store & Known Developers"
@@ -445,6 +461,11 @@ configure_computer_name() {
 
 configure_night_shift() {
   print_header "Night Shift"
+
+  if ! command -v nightlight &>/dev/null; then
+    echo -e "  ${YELLOW}○${NC} nightlight not installed (brew install smudge/smudge/nightlight)"
+    return 0
+  fi
 
   nightlight schedule start
   nightlight temp 50
@@ -506,14 +527,9 @@ configure_login_items() {
   add_login_item "/Applications/Raycast.app" "Raycast"
   add_login_item "/Applications/1Password.app" "1Password"
   add_login_item "/Applications/iStatistica Pro.app" "iStatistica Pro"
-  add_login_item "/Applications/Rectangle.app" "Rectangle"
   add_login_item "/Applications/Ice.app" "Ice"
-  add_login_item "/Applications/BetterMouse.app" "BetterMouse"
   add_login_item "/Applications/OrbStack.app" "OrbStack"
   add_login_item "/Applications/Elgato Control Center.app" "Elgato Control Center"
-  add_login_item "/Applications/Bartender 5.app" "Bartender 5"
-  add_login_item "/Applications/Alfred 5.app" "Alfred 5"
-  add_login_item "/Applications/Synology Drive Client.app" "Synology Drive Client"
 }
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Pre-bootstrap cleanup pass for the new MacBook Pro M5. Brewfile additions/removals, five real bugs in `setup_macos_defaults.sh`, dead login items, and stale shell integrations.

## Brewfile

**`.Brewfile.core`** — added: `lazygit`, `difftastic`, `just`, `opentofu`. Removed: `colordiff` (git-delta covers it).

**`.Brewfile.extras`** — added:
- Shell/CLI: `atuin`, `yazi`, `dust`, `procs`, `sd`, `fastfetch`, `hyperfine`, `tokei`, `gron`, `mods`, `vale`, `xh`
- K8s/SRE: `dive`, `kubeseal`, `flux`, `argocd`, `talosctl`, `crane`, both `kubelogin` variants
- GUI: `bruno` cask
- 4 new taps (`fluxcd/tap`, `siderolabs/tap`, `Azure/kubelogin`, `int128/kubelogin`)

**`.Brewfile.extras`** — removed: `neofetch` (archived 2024), `thefuck` (atuin replaces), `telnet`, `gnu-indent`, `b2-tools`, `devcleaner`, `lens`, `postman`. Cmux comment fixed (was cut off mid-sentence).

## `setup_macos_defaults.sh` bugs

1. `configure_remote_login`: missing `return 0` after the "already enabled" check — was always re-running `setremotelogin on`
2. `sudo spctl --master-enable` → `--global-enable` (deprecated since macOS Ventura)
3. `disable-shadow -bool false` → `true` — value was inverted; comment was correct
4. Dropped `AppleMenuBarVisibleInFullscreen` line — key doesn't exist; `_HIHideMenuBar` (already set) is the working one
5. Added `command -v nightlight` guard so the function no-ops cleanly if nightlight isn't installed yet

## New macOS defaults

- `ApplePressAndHoldEnabled false` — vim/Neovim key repeat
- `com.apple.ImageCapture disableHotPlug true` — block Photos auto-launch on camera/SD card connect
- `_FXShowPosixPathInTitle true` — POSIX path in Finder title bar
- `NSDocumentSaveNewDocumentsToCloud false` — default to local disk

## Login items

Dropped: Rectangle, BetterMouse, Bartender 5, Alfred 5, Synology Drive Client. None were in the Brewfile and Alfred/Bartender are superseded by Raycast/Ice.

## Shell integration

- `atuin.fish`: only source `~/.atuin/bin/env.fish` if it exists. Brew installs put atuin on PATH directly, so the manual-installer's env.fish wouldn't exist.
- `integration.fish`: thefuck block removed.

## Linux

- `install_linux.sh`: `neofetch` → `fastfetch` in extras (package list + menu text).

## Heads-up

**`Azure/kubelogin` and `int128/kubelogin` both ship a binary named `kubelogin` and will collide on install.** I included both per the request, with a comment in the extras file flagging it. Pick one if `brew bundle` errors.

## Test plan

- [ ] `brew bundle check --file=.Brewfile.core` on the new MBP
- [ ] `brew bundle check --file=.Brewfile.extras` (resolve kubelogin collision if it errors)
- [ ] Run `setup_macos_defaults.sh` end-to-end; verify Remote Login doesn't double-prompt and nightlight no-op path works
- [ ] `defaults read NSGlobalDomain ApplePressAndHoldEnabled` returns `0`
- [ ] Verify atuin works in fish after fresh brew install (no env.fish present)

---
_Generated by [Claude Code](https://claude.ai/code/session_012aCbftMYvjruuTDAzsUnkG)_